### PR TITLE
Computed property check

### DIFF
--- a/Sources/DummyableMacro/Extensions/Syntax/DeclSyntax/VariableDeclSyntax+Extensions.swift
+++ b/Sources/DummyableMacro/Extensions/Syntax/DeclSyntax/VariableDeclSyntax+Extensions.swift
@@ -12,7 +12,7 @@ extension VariableDeclSyntax {
     typealias DTS = DummyableTokenSyntaxes
     
     var shouldBeAssignedFromInit: Bool {
-        guard let binding = self.bindings.first, binding.initializer == nil, !hasGetter else {
+        guard let binding = self.bindings.first, binding.initializer == nil, !hasGetter, !isComputedProperty else {
             return false
         }
         return true
@@ -34,6 +34,19 @@ extension VariableDeclSyntax {
     
     var hasSetter: Bool {
         accessors?.contains { $0.accessorSpecifier.text == DTS.set.text } ?? false
+    }
+    
+    var isComputedProperty: Bool {
+        guard let accessorsBlock = bindings.first?.accessorBlock else {
+            return false
+        }
+        guard let accessors = accessorsBlock.accessors.as(AccessorDeclListSyntax.self) else {
+            return true
+        }
+        return accessors.contains { accessor in
+            let text = accessor.accessorSpecifier.text
+            return text == DTS.get.text
+        }
     }
     
     var extraction: VariableDeclExtraction? {

--- a/Tests/DummyableTests/DummyableMacroOnClassTests.swift
+++ b/Tests/DummyableTests/DummyableMacroOnClassTests.swift
@@ -34,6 +34,9 @@ class Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(string: String?, int: Int = 10) {
@@ -49,6 +52,9 @@ class Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(string: String?, int: Int = 10) {
@@ -105,6 +111,9 @@ class Some<T: Equatable> where T: Hashable {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(generic: T?, int: Int = 10) {
@@ -120,6 +129,9 @@ class Some<T: Equatable> where T: Hashable {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(generic: T?, int: Int = 10) {

--- a/Tests/DummyableTests/DummyableMacroOnEnumTests.swift
+++ b/Tests/DummyableTests/DummyableMacroOnEnumTests.swift
@@ -48,6 +48,9 @@ enum Some {
     case another
     case withParameter(string: String, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -57,6 +60,9 @@ enum Some {
     case another
     case withParameter(string: String, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 
 func dummy(of type: Some.Type) -> Some {
@@ -106,6 +112,9 @@ enum Some {
     case oneParameter(string: String)
     case twoParameter(string: String, int: Int)
     case threeParameter(string: String, int: Int, double: Double)
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -114,6 +123,9 @@ enum Some {
     case oneParameter(string: String)
     case twoParameter(string: String, int: Int)
     case threeParameter(string: String, int: Int, double: Double)
+    var someComputed: String {
+        "computed"
+    }
 }
 
 func dummy(of type: Some.Type) -> Some {
@@ -164,6 +176,9 @@ enum Some {
     case another
     @DummyableCase case withParameter(string: String, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -173,6 +188,9 @@ enum Some {
     case another
     @DummyableCase case withParameter(string: String, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 
 func dummy(of type: Some.Type) -> Some {
@@ -223,6 +241,9 @@ enum Some<T: Equatable> {
     case another
     case withParameter(generic: T, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -232,6 +253,9 @@ enum Some<T: Equatable> {
     case another
     case withParameter(generic: T, int: Int)
     case none
+    var someComputed: String {
+        "computed"
+    }
 }
 
 func dummy<T: Equatable>(of type: Some<T>.Type) -> Some<T> {

--- a/Tests/DummyableTests/DummyableMacroOnStructTests.swift
+++ b/Tests/DummyableTests/DummyableMacroOnStructTests.swift
@@ -41,6 +41,9 @@ struct Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -50,6 +53,9 @@ struct Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     init(string: String? = dummy(of: String?.self), int: Int = dummy(of: Int.self)) {
         self.string = string
@@ -105,6 +111,9 @@ private struct Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(string: String?, int: Int = 10) {
@@ -120,6 +129,9 @@ private struct Some {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     @DummyableInit
     init(string: String?, int: Int = 10) {
@@ -176,6 +188,9 @@ struct Some<T: Equatable> where T: Hashable {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 }
 """#
 
@@ -185,6 +200,9 @@ struct Some<T: Equatable> where T: Hashable {
     let int: Int
     var doubles: [Double] = []
     let floats: Float = 0.0
+    var someComputed: String {
+        "computed"
+    }
 
     init(generic: T? = dummy(of: T?.self), int: Int = dummy(of: Int.self)) {
         self.generic = generic


### PR DESCRIPTION
This pull request introduces enhancements to the `DummyableMacro` functionality, focusing on computed property detection and expanding test coverage across various Swift constructs. The key changes include adding a mechanism to identify computed properties in `VariableDeclSyntax` and updating test cases for classes, enums, and structs to include computed properties.

### Enhancements to computed property detection:

* **Computed property check in `VariableDeclSyntax`:** Added the `isComputedProperty` property to detect computed properties in variable declarations. Updated the `shouldBeAssignedFromInit` logic to exclude computed properties. (`Sources/DummyableMacro/Extensions/Syntax/DeclSyntax/VariableDeclSyntax+Extensions.swift`) [[1]](diffhunk://#diff-375d72096d6d23263e2e3b9774fbeeaf322fdfd324f16dd1507c9d189434835cL15-R15) [[2]](diffhunk://#diff-375d72096d6d23263e2e3b9774fbeeaf322fdfd324f16dd1507c9d189434835cR39-R51)

### Updates to test cases:

* **Class tests:** Added `someComputed` computed property to test cases for classes, including generic and non-generic scenarios. (`Tests/DummyableTests/DummyableMacroOnClassTests.swift`) [[1]](diffhunk://#diff-bcd3cb2008271ee3c10211c5340616fba1ecbbaa0b99e912b93380028a4a0f03R37-R39) [[2]](diffhunk://#diff-bcd3cb2008271ee3c10211c5340616fba1ecbbaa0b99e912b93380028a4a0f03R55-R57) [[3]](diffhunk://#diff-bcd3cb2008271ee3c10211c5340616fba1ecbbaa0b99e912b93380028a4a0f03R114-R116) [[4]](diffhunk://#diff-bcd3cb2008271ee3c10211c5340616fba1ecbbaa0b99e912b93380028a4a0f03R132-R134)
* **Enum tests:** Included `someComputed` computed property in test cases for enums, covering regular and generic enums with varying parameter configurations. (`Tests/DummyableTests/DummyableMacroOnEnumTests.swift`) [[1]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R51-R53) [[2]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R63-R65) [[3]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R115-R117) [[4]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R126-R128) [[5]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R179-R181) [[6]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R191-R193) [[7]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R244-R246) [[8]](diffhunk://#diff-3f4dc92e586329dffdb02211104185f7828bf7f854a5716cb1ae0a2ff2d7e0a3R256-R258)
* **Struct tests:** Added `someComputed` computed property to test cases for structs, including private and generic structs. (`Tests/DummyableTests/DummyableMacroOnStructTests.swift`) [[1]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR44-R46) [[2]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR56-R58) [[3]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR114-R116) [[4]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR132-R134) [[5]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR191-R193) [[6]](diffhunk://#diff-4560998509a9809272b62a8ad0b4e496f58093fac8dbdb1a1cedc61713d5e0bdR203-R205)