### PR TITLE
Refactor to use any Keyword for protocol dummy

### DIFF
--- a/Sources/DummyableMacro/Extraction/FreestandingMacroExtraction.swift
+++ b/Sources/DummyableMacro/Extraction/FreestandingMacroExtraction.swift
@@ -15,7 +15,7 @@ struct FreestandingMacroExtraction {
     
     @inlinable init(from node: FreestandingMacroExpansionSyntax) throws {
         
-        guard let expression = node.argumentList.first?.expression.as(MemberAccessExprSyntax.self)?.base,
+        guard let expression = node.arguments.first?.expression.as(MemberAccessExprSyntax.self)?.base,
               let closure = node.lastClosure else {
             throw DummyableMacroError.wrongArguments
         }
@@ -23,13 +23,13 @@ struct FreestandingMacroExtraction {
         self.closure = closure
         
         self.metaDatas = (
-            node.argumentList.dropFirst().compactMap { FreestandingMetaData(from: $0) }
+            node.arguments.dropFirst().compactMap { FreestandingMetaData(from: $0) }
             + expression.genericMetaDatas()
         ).compacted()
         
         self.type = expression.identifierTypeSyntax(metaDatas: metaDatas)
         
-        self.modifiers = switch node.macro.trimmedDescription {
+        self.modifiers = switch node.macroName.trimmedDescription {
         case "PublicDummy", "Dummyable.PublicDummy": [.public]
         case "PrivateDummy", "Dummyable.PrivateDummy": [.private]
         default: []

--- a/Sources/DummyableMacro/Extraction/ProtocolDeclExtraction.swift
+++ b/Sources/DummyableMacro/Extraction/ProtocolDeclExtraction.swift
@@ -84,7 +84,7 @@ extension DummyFuncUsingInitDeclFactory {
 extension DummyFuncForClosuresDeclFactory {
     @inlinable init(protocolExtraction: ProtocolDeclExtraction) {
         self.init(
-            typeExtraction: protocolExtraction,
+            protocolExtraction: protocolExtraction,
             creationType: .emptyInitCall(protocolExtraction.generationName)
         )
     }
@@ -95,7 +95,7 @@ extension DummyFuncForClosuresDeclFactory {
 extension DummyFuncForArrayDeclFactory {
     @inlinable init(protocolExtraction: ProtocolDeclExtraction) {
         self.init(
-            typeExtraction: protocolExtraction,
+            protocolExtraction: protocolExtraction,
             creationType: .emptyInitCall(protocolExtraction.generationName)
         )
     }

--- a/Sources/DummyableMacro/Extraction/TypeDeclExtraction.swift
+++ b/Sources/DummyableMacro/Extraction/TypeDeclExtraction.swift
@@ -88,6 +88,24 @@ extension DummyFuncForClosuresDeclFactory {
                 creationType: creationType
             )
         }
+    
+    @inlinable init(
+        protocolExtraction: ProtocolDeclExtraction,
+        creationType: DummyCreationType = .dummyFuncCall) {
+            self.init(
+                attributes: protocolExtraction.usableAttributes,
+                modifiers: protocolExtraction.modifiers.onlyAccessModifier(),
+                genericParameters: protocolExtraction.genericParameters,
+                returnType: SomeOrAnyTypeSyntax(
+                    someOrAnySpecifier: .keyword(.any),
+                    constraint: IdentifierTypeSyntax(
+                        name: protocolExtraction.declName
+                    )
+                ),
+                genericWhereClause: protocolExtraction.genericWhereClause,
+                creationType: creationType
+            )
+        }
 }
 
 // MARK: DummiesFuncDeclFactory + Extensions
@@ -105,6 +123,24 @@ extension DummyFuncForArrayDeclFactory {
                     genericArgumentClause: typeExtraction.genericParameters?.asGenericArgumentClause
                 ),
                 genericWhereClause: typeExtraction.genericWhereClause,
+                creationType: creationType
+            )
+        }
+    
+    @inlinable init(
+        protocolExtraction: ProtocolDeclExtraction,
+        creationType: DummyCreationType = .dummyFuncCall) {
+            self.init(
+                attributes: protocolExtraction.usableAttributes,
+                modifiers: protocolExtraction.modifiers.onlyAccessModifier(),
+                genericParameters: protocolExtraction.genericParameters,
+                elementType: SomeOrAnyTypeSyntax(
+                    someOrAnySpecifier: .keyword(.any),
+                    constraint: IdentifierTypeSyntax(
+                        name: protocolExtraction.declName
+                    )
+                ),
+                genericWhereClause: protocolExtraction.genericWhereClause,
                 creationType: creationType
             )
         }

--- a/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncDeclFactory.swift
+++ b/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncDeclFactory.swift
@@ -49,7 +49,7 @@ struct DummyFuncDeclFactory {
             parameterClause: FunctionParameterClauseSyntax(
                 parameters: buildDummyFuncParams(additionalParam: additionalParam)
             ),
-            returnClause: ReturnClauseSyntax(type: returnType)
+            returnClause: returnClause()
         )
     }
     
@@ -83,6 +83,18 @@ struct DummyFuncDeclFactory {
                 )
             }),
             name: DTS.typeType
+        )
+    }
+    
+    private func returnClause() -> ReturnClauseSyntax {
+        guard isProtocol else {
+            return ReturnClauseSyntax(type: returnType)
+        }
+        return ReturnClauseSyntax(
+            type: SomeOrAnyTypeSyntax(
+                someOrAnySpecifier: .keyword(.any),
+                constraint: returnType
+            )
         )
     }
 }

--- a/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForArrayDeclFactory.swift
+++ b/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForArrayDeclFactory.swift
@@ -13,14 +13,14 @@ struct DummyFuncForArrayDeclFactory: DeclBuilder, DummyClosureCreationExprBuilde
     
     private let attributes: AttributeListSyntax
     private let modifiers: DeclModifierListSyntax
-    private let elementType: IdentifierTypeSyntax
+    private let elementType: TypeSyntaxProtocol
     private let genericParameters: GenericParameterListSyntax?
     private let genericWhereClause: GenericWhereClauseSyntax?
     private let creationType: DummyCreationType
     
     @inlinable init(
         attributes: AttributeListSyntax, modifiers: DeclModifierListSyntax,
-        genericParameters: GenericParameterListSyntax?, elementType: IdentifierTypeSyntax,
+        genericParameters: GenericParameterListSyntax?, elementType: TypeSyntaxProtocol,
         genericWhereClause: GenericWhereClauseSyntax?, creationType: DummyCreationType) {
             self.attributes = attributes
             self.modifiers = modifiers

--- a/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForClosureDeclFactory.swift
+++ b/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForClosureDeclFactory.swift
@@ -14,7 +14,7 @@ struct DummyFuncForClosureDeclFactory: DeclBuilder, DummyClosureCreationExprBuil
     private let closureType: ClosureType
     private let attributes: AttributeListSyntax
     private let modifiers: DeclModifierListSyntax
-    private let returnType: IdentifierTypeSyntax
+    private let returnType: TypeSyntaxProtocol
     private let genericParameters: GenericParameterListSyntax?
     private let genericWhereClause: GenericWhereClauseSyntax?
     private let creationType: DummyCreationType
@@ -24,7 +24,7 @@ struct DummyFuncForClosureDeclFactory: DeclBuilder, DummyClosureCreationExprBuil
     @inlinable init(
         closureType: ClosureType, attributes: AttributeListSyntax,
         modifiers: DeclModifierListSyntax, genericParameters: GenericParameterListSyntax?,
-        returnType: IdentifierTypeSyntax, genericWhereClause: GenericWhereClauseSyntax?,
+        returnType: TypeSyntaxProtocol, genericWhereClause: GenericWhereClauseSyntax?,
         creationType: DummyCreationType) {
             self.closureType = closureType
             self.attributes = attributes
@@ -94,7 +94,7 @@ struct DummyFuncForClosureDeclFactory: DeclBuilder, DummyClosureCreationExprBuil
         )
     }
     
-    private func buildReturnType(forType type: IdentifierTypeSyntax) -> IdentifierTypeSyntax {
+    private func buildReturnType(forType type: TypeSyntaxProtocol) -> TypeSyntaxProtocol {
         var additive = 0
         return IdentifierTypeSyntax(
             name: closureType.type,

--- a/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForClosuresDeclFactory.swift
+++ b/Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForClosuresDeclFactory.swift
@@ -14,7 +14,7 @@ struct DummyFuncForClosuresDeclFactory: ArrayDeclBuilder {
     
     @inlinable init(
         attributes: AttributeListSyntax, modifiers: DeclModifierListSyntax,
-        genericParameters: GenericParameterListSyntax?, returnType: IdentifierTypeSyntax,
+        genericParameters: GenericParameterListSyntax?, returnType: TypeSyntaxProtocol,
         genericWhereClause: GenericWhereClauseSyntax?, creationType: DummyCreationType) {
             closureFuncDeclFactory = [
                 ClosureType.noArg, ClosureType.oneArg,

--- a/Tests/DummyableTests/DummyableMacroOnProtocolTests.swift
+++ b/Tests/DummyableTests/DummyableMacroOnProtocolTests.swift
@@ -69,41 +69,41 @@ private struct SomeDummy: Some {
     }
 }
 
-func dummy(of type: (any Some).Type) -> Some {
+func dummy(of type: (any Some).Type) -> any Some {
     SomeDummy()
 }
 
-func dummy(of type: [Some].Type, count: Int) -> [Some] {
+func dummy(of type: [any Some].Type, count: Int) -> [any Some] {
     Array(repeat: count) {
         SomeDummy()
     }
 }
 
-func dummy(of type: Closure<Some>.Type) -> Closure<Some> {
+func dummy(of type: Closure<any Some>.Type) -> Closure<any Some> {
     {
         SomeDummy()
     }
 }
 
-func dummy<A>(of type: ArgClosure<A, Some>.Type) -> ArgClosure<A, Some> {
+func dummy<A>(of type: ArgClosure<A, any Some>.Type) -> ArgClosure<A, any Some> {
     { _ in
         SomeDummy()
     }
 }
 
-func dummy<A, B>(of type: TwoArgsClosure<A, B, Some>.Type) -> TwoArgsClosure<A, B, Some> {
+func dummy<A, B>(of type: TwoArgsClosure<A, B, any Some>.Type) -> TwoArgsClosure<A, B, any Some> {
     { _, _ in
         SomeDummy()
     }
 }
 
-func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, Some>.Type) -> ThreeArgsClosure<A, B, C, Some> {
+func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, any Some>.Type) -> ThreeArgsClosure<A, B, C, any Some> {
     { _, _, _ in
         SomeDummy()
     }
 }
 
-func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, Some>.Type) -> FourArgsClosure<A, B, C, D, Some> {
+func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, any Some>.Type) -> FourArgsClosure<A, B, C, D, any Some> {
     { _, _, _, _ in
         SomeDummy()
     }
@@ -145,41 +145,41 @@ final private class SomeDummy: Some {
     }
 }
 
-private func dummy(of type: (any Some).Type) -> Some {
+private func dummy(of type: (any Some).Type) -> any Some {
     SomeDummy()
 }
 
-private func dummy(of type: [Some].Type, count: Int) -> [Some] {
+private func dummy(of type: [any Some].Type, count: Int) -> [any Some] {
     Array(repeat: count) {
         SomeDummy()
     }
 }
 
-private func dummy(of type: Closure<Some>.Type) -> Closure<Some> {
+private func dummy(of type: Closure<any Some>.Type) -> Closure<any Some> {
     {
         SomeDummy()
     }
 }
 
-private func dummy<A>(of type: ArgClosure<A, Some>.Type) -> ArgClosure<A, Some> {
+private func dummy<A>(of type: ArgClosure<A, any Some>.Type) -> ArgClosure<A, any Some> {
     { _ in
         SomeDummy()
     }
 }
 
-private func dummy<A, B>(of type: TwoArgsClosure<A, B, Some>.Type) -> TwoArgsClosure<A, B, Some> {
+private func dummy<A, B>(of type: TwoArgsClosure<A, B, any Some>.Type) -> TwoArgsClosure<A, B, any Some> {
     { _, _ in
         SomeDummy()
     }
 }
 
-private func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, Some>.Type) -> ThreeArgsClosure<A, B, C, Some> {
+private func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, any Some>.Type) -> ThreeArgsClosure<A, B, C, any Some> {
     { _, _, _ in
         SomeDummy()
     }
 }
 
-private func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, Some>.Type) -> FourArgsClosure<A, B, C, D, Some> {
+private func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, any Some>.Type) -> FourArgsClosure<A, B, C, D, any Some> {
     { _, _, _, _ in
         SomeDummy()
     }
@@ -219,41 +219,41 @@ final private class SomeDummy: Some {
     }
 }
 
-public func dummy(of type: (any Some).Type) -> Some {
+public func dummy(of type: (any Some).Type) -> any Some {
     SomeDummy()
 }
 
-public func dummy(of type: [Some].Type, count: Int) -> [Some] {
+public func dummy(of type: [any Some].Type, count: Int) -> [any Some] {
     Array(repeat: count) {
         SomeDummy()
     }
 }
 
-public func dummy(of type: Closure<Some>.Type) -> Closure<Some> {
+public func dummy(of type: Closure<any Some>.Type) -> Closure<any Some> {
     {
         SomeDummy()
     }
 }
 
-public func dummy<A>(of type: ArgClosure<A, Some>.Type) -> ArgClosure<A, Some> {
+public func dummy<A>(of type: ArgClosure<A, any Some>.Type) -> ArgClosure<A, any Some> {
     { _ in
         SomeDummy()
     }
 }
 
-public func dummy<A, B>(of type: TwoArgsClosure<A, B, Some>.Type) -> TwoArgsClosure<A, B, Some> {
+public func dummy<A, B>(of type: TwoArgsClosure<A, B, any Some>.Type) -> TwoArgsClosure<A, B, any Some> {
     { _, _ in
         SomeDummy()
     }
 }
 
-public func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, Some>.Type) -> ThreeArgsClosure<A, B, C, Some> {
+public func dummy<A, B, C>(of type: ThreeArgsClosure<A, B, C, any Some>.Type) -> ThreeArgsClosure<A, B, C, any Some> {
     { _, _, _ in
         SomeDummy()
     }
 }
 
-public func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, Some>.Type) -> FourArgsClosure<A, B, C, D, Some> {
+public func dummy<A, B, C, D>(of type: FourArgsClosure<A, B, C, D, any Some>.Type) -> FourArgsClosure<A, B, C, D, any Some> {
     { _, _, _, _ in
         SomeDummy()
     }


### PR DESCRIPTION
This pull request introduces several updates to improve type handling, enhance factory initialization, and align test implementations with the updated type system. Key changes include transitioning to `TypeSyntaxProtocol` for better type abstraction, adding new initializers for factory classes, and updating test cases to use `any Some` for type consistency.

### Type Handling Improvements:
* Replaced `IdentifierTypeSyntax` with `TypeSyntaxProtocol` in `DummyFuncForArrayDeclFactory` and `DummyFuncForClosureDeclFactory` to support broader type definitions. (`Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForArrayDeclFactory.swift` [[1]](diffhunk://#diff-ce0c2032864bc7e67ba0394d4190371640fbd245c3f636406ee33cfc77c171baL16-R23) `Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncForClosureDeclFactory.swift` [[2]](diffhunk://#diff-3b79da8e5344add62af6dffc5219ddb700bdeca5f9a5970caf7efb89bdebb811L17-R17) [[3]](diffhunk://#diff-3b79da8e5344add62af6dffc5219ddb700bdeca5f9a5970caf7efb89bdebb811L27-R27) [[4]](diffhunk://#diff-3b79da8e5344add62af6dffc5219ddb700bdeca5f9a5970caf7efb89bdebb811L97-R97)

### Factory Class Enhancements:
* Added new initializers to `DummyFuncForClosuresDeclFactory` and `DummyFuncForArrayDeclFactory` to streamline creation using `ProtocolDeclExtraction` and support `DummyCreationType`. (`Sources/DummyableMacro/Extraction/TypeDeclExtraction.swift` [[1]](diffhunk://#diff-b9e3c50415ccbd4fcc47202b01b51d4daf49efda0c5c941c7d68bc57b23b0284R91-R108) [[2]](diffhunk://#diff-b9e3c50415ccbd4fcc47202b01b51d4daf49efda0c5c941c7d68bc57b23b0284R129-R146)

### Test Updates:
* Refactored test functions to use `any Some` for improved type clarity and alignment with updated type system. (`Tests/DummyableTests/DummyableMacroOnProtocolTests.swift` [[1]](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fL72-R106) [[2]](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fL148-R182) [[3]](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fL222-R256)

### Other Refinements:
* Simplified `DummyFuncDeclFactory` by introducing a helper method `returnClause()` to handle conditional return type creation. (`Sources/DummyableMacro/Factory/DummyFuncFactory/DummyFuncDeclFactory.swift` [[1]](diffhunk://#diff-1c684c16506b736524139e1ad8a38488e370b4dfedd4a7f526a1c228534e2531L52-R52) [[2]](diffhunk://#diff-1c684c16506b736524139e1ad8a38488e370b4dfedd4a7f526a1c228534e2531R88-R99)
* Adjusted parameter names in initializers for consistency and clarity across factory classes. (`Sources/DummyableMacro/Extraction/ProtocolDeclExtraction.swift` [[1]](diffhunk://#diff-ae59364e214028bb91cb8f036ce5df80cc352d75fbfaf143bf077560c82c7399L87-R87) [[2]](diffhunk://#diff-ae59364e214028bb91cb8f036ce5df80cc352d75fbfaf143bf077560c82c7399L98-R98)