### PR TITLE
Add handling for any type

### DIFF
--- a/Sources/DummyableMacro/Factory/Protocol/DummyFuncCallExprBuilder.swift
+++ b/Sources/DummyableMacro/Factory/Protocol/DummyFuncCallExprBuilder.swift
@@ -24,7 +24,7 @@ extension DummyFuncCallExprBuilder {
                     label: DummyableTokenSyntaxes.of,
                     colon: .colonToken(),
                     expression: MemberAccessExprSyntax(
-                        base: DeclReferenceExprSyntax(baseName: .identifier(type.trimmedDescription)),
+                        base: buildDummyFuncBaseExpr(forType: type),
                         period: .periodToken(),
                         name: .keyword(.self)
                     )
@@ -32,5 +32,20 @@ extension DummyFuncCallExprBuilder {
             },
             rightParen: .rightParenToken()
         )
+    }
+    
+    private func buildDummyFuncBaseExpr(forType type: TypeSyntax) -> ExprSyntaxProtocol {
+        return if let anyTypeSyntax = type.as(SomeOrAnyTypeSyntax.self) {
+            TupleExprSyntax(elements: LabeledExprListSyntax {
+                LabeledExprSyntax(
+                    expression: DeclReferenceExprSyntax(
+                        baseName: .identifier(anyTypeSyntax.trimmedDescription)
+                    )
+                )
+            })
+        } else {
+            DeclReferenceExprSyntax(baseName: .identifier(type.trimmedDescription))
+        }
+        
     }
 }

--- a/Tests/DummyableTests/DummyableMacroOnProtocolTests.swift
+++ b/Tests/DummyableTests/DummyableMacroOnProtocolTests.swift
@@ -42,6 +42,7 @@ protocol Some {
     init?(int: Int)
     func voidFunc() async throws
     func returnFunc(arg argument: String) async throws -> String
+    func returnAnyFunc() -> any Some
 }
 """#
 
@@ -52,6 +53,7 @@ protocol Some {
     init?(int: Int)
     func voidFunc() async throws
     func returnFunc(arg argument: String) async throws -> String
+    func returnAnyFunc() -> any Some
 }
 
 private struct SomeDummy: Some {
@@ -66,6 +68,9 @@ private struct SomeDummy: Some {
     }
     func returnFunc(arg argument: String) async throws -> String {
         dummy(of: String.self)
+    }
+    func returnAnyFunc() -> any Some {
+        dummy(of: (any Some).self)
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new utility method to handle `any` types in dummy function call expressions and updates related test cases to ensure proper functionality. The most important changes include adding the `buildDummyFuncBaseExpr` method, modifying the expression construction logic, and extending the test protocol and its dummy implementation.

### Enhancements to Dummy Function Call Expression Construction:

* [`Sources/DummyableMacro/Factory/Protocol/DummyFuncCallExprBuilder.swift`](diffhunk://#diff-3634d6e80cde922cbcd035b016585882220ab132be7f706bd009c1e20d121248L27-R27): Replaced direct `DeclReferenceExprSyntax` usage with the new `buildDummyFuncBaseExpr` method, which dynamically handles `any` types by constructing either a tuple expression or a declaration reference based on the type. [[1]](diffhunk://#diff-3634d6e80cde922cbcd035b016585882220ab132be7f706bd009c1e20d121248L27-R27) [[2]](diffhunk://#diff-3634d6e80cde922cbcd035b016585882220ab132be7f706bd009c1e20d121248R36-R50)

### Updates to Test Protocol and Dummy Implementation:

* [`Tests/DummyableTests/DummyableMacroOnProtocolTests.swift`](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fR45): Added a new method `returnAnyFunc` to the `Some` protocol to test the handling of `any` types. [[1]](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fR45) [[2]](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fR56)
* [`Tests/DummyableTests/DummyableMacroOnProtocolTests.swift`](diffhunk://#diff-7bce55e652b9b5094bed02094a94325c16dac02815dac92e7a5246281c8d2d4fR72-R74): Implemented the `returnAnyFunc` method in the `SomeDummy` struct, using the `dummy` function to return a dummy instance of `any Some`.