### PR TITLE
Add default support for AsyncStream and AsyncThrowingStream

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
       run: |
         swift build -v
         swift test -v
-    - name: Run Tests on iPhone 16 Simulator (iOS 18.2)
+    - name: Run Tests on iPhone 16 Simulator (iOS 18.4)
       run: |
         xcodebuild test \
           -scheme 'Dummyable' \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' \
+          -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
           -skipPackagePluginValidation

--- a/Sources/Dummyable/DummyProvider/Dummies+Async.swift
+++ b/Sources/Dummyable/DummyProvider/Dummies+Async.swift
@@ -1,0 +1,20 @@
+//
+//  Dummies+Async.swift
+//  Dummyable
+//
+//  Created by Nayanda Haberty on 27/09/25.
+//
+
+import Foundation
+
+#PublicDummy(
+    of: AsyncThrowingStream<Generic,
+    Error>.self,
+    .where(1, conform: Error.self)
+) {
+    AsyncThrowingStream { $0.finish() }
+}
+
+#PublicDummy(of: AsyncStream<Generic>.self) {
+    AsyncStream { $0.finish() }
+}

--- a/Sources/Dummyable/DummyProvider/Dummies+Async.swift
+++ b/Sources/Dummyable/DummyProvider/Dummies+Async.swift
@@ -7,14 +7,6 @@
 
 import Foundation
 
-#PublicDummy(
-    of: AsyncThrowingStream<Generic,
-    Error>.self,
-    .where(1, conform: Error.self)
-) {
-    AsyncThrowingStream { $0.finish() }
-}
-
 #PublicDummy(of: AsyncStream<Generic>.self) {
     AsyncStream { $0.finish() }
 }


### PR DESCRIPTION
This pull request adds new dummy implementations for asynchronous stream types to the `Dummyable` library, making it easier to mock or test code that relies on Swift's async streams.

**New dummy providers for async streams:**

* Added a public dummy for `AsyncThrowingStream<Generic, Error>` that immediately finishes the stream.
* Added a public dummy for `AsyncStream<Generic>` that immediately finishes the stream.